### PR TITLE
SPOI-11557 Added metrics support for Jdbc poller and output operator.

### DIFF
--- a/app-templates/database-to-database-sync/pom.xml
+++ b/app-templates/database-to-database-sync/pom.xml
@@ -1,9 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  
+  <parent>
+    <groupId>com.datatorrent.apps</groupId>
+    <artifactId>moodi-app-templates</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+  </parent>
   <groupId>com.datatorrent.apps</groupId>
-  <version>0.9.0</version>
+  <version>0.10.0</version>
   <artifactId>database-to-database-sync</artifactId>
   <packaging>jar</packaging>
 
@@ -12,10 +16,7 @@
   <description>Ingest messages from a source PostgreSQL Database table to destination PostgreSQL database table.</description>
 
   <properties>
-    <!-- change this if you desire to use a different version of Apex Core -->
-    <apex.version>3.4.0</apex.version>
     <apex.apppackage.classpath>lib/*.jar</apex.apppackage.classpath>
-    <malhar.version>3.6.0</malhar.version>
     <apex.apppackage.tags>app-template, db, PostgreSQL, sync</apex.apppackage.tags>
     <apex.apppackage.longDescription>README.md</apex.apppackage.longDescription>
     <!-- skip tests by default as they depend on manual setup -->

--- a/app-templates/database-to-database-sync/src/main/java/com/datatorrent/apps/Application.java
+++ b/app-templates/database-to-database-sync/src/main/java/com/datatorrent/apps/Application.java
@@ -32,12 +32,12 @@ import com.datatorrent.api.DAG;
 import com.datatorrent.api.StreamingApplication;
 import com.datatorrent.api.annotation.ApplicationAnnotation;
 import com.datatorrent.lib.db.jdbc.JdbcFieldInfo;
-import com.datatorrent.lib.db.jdbc.JdbcPOJOInsertOutputOperator;
-import com.datatorrent.lib.db.jdbc.JdbcPOJOPollInputOperator;
 import com.datatorrent.lib.db.jdbc.JdbcStore;
 import com.datatorrent.lib.db.jdbc.JdbcTransactionalStore;
 import com.datatorrent.lib.transform.TransformOperator;
 import com.datatorrent.lib.util.FieldInfo;
+import com.datatorrent.moodi.lib.io.db.JdbcPOJOInsertOutputOperator;
+import com.datatorrent.moodi.lib.io.db.JdbcPOJOPollInputOperator;
 
 @ApplicationAnnotation(name="Database-to-Database-Sync")
 public class Application implements StreamingApplication
@@ -71,6 +71,7 @@ public class Application implements StreamingApplication
      */
     dag.addStream("JdbcInput-to-JdbcOutput", jdbcInputOperator.outputPort, jdbcOutputOperator.input);
     dag.setInputPortAttribute(jdbcOutputOperator.input, Context.PortContext.PARTITION_PARALLEL, true);
+    dag.setAttribute(Context.DAGContext.METRICS_TRANSPORT, null);
 
     /*
      * To add custom logic to your DAG, add your custom operator here with

--- a/app-templates/database-to-database-sync/src/main/resources/META-INF/properties.xml
+++ b/app-templates/database-to-database-sync/src/main/resources/META-INF/properties.xml
@@ -73,7 +73,7 @@
 
   <property>
     <name>apex.app-param.whereCondition</name>
-    <value></value>
+    <value>1=1</value>
     <description>Specify WHERE clause for input database. Note if blank value specified, all records would be selected</description>
   </property>
   <property>
@@ -220,6 +220,11 @@
   <property>
     <name>dt.operator.transform.port.output.attr.TUPLE_CLASS</name>
     <value>${apex.app-param.tupleClassNameForTransformOutput}</value>
+  </property>
+
+  <property>
+    <name>apex.plugin.stram.plugins</name>
+    <value>com.datatorrent.metrics.plugin.MetricWriterPlugin</value>
   </property>
 
 </configuration>

--- a/app-templates/database-to-database-sync/src/main/resources/resources/ui/dashboards/Database-to-Database-Sync.dtdashboard
+++ b/app-templates/database-to-database-sync/src/main/resources/resources/ui/dashboards/Database-to-Database-Sync.dtdashboard
@@ -1,0 +1,2924 @@
+{
+    "config": {
+        "applications": [
+            {
+                "name": "Database-to-Database-Sync",
+                "user": "deepak"
+            }
+        ],
+        "state": {
+            "widgets": [
+                {
+                    "dataModelOptions": {
+                        "allowFetchData": true,
+                        "dataQueryParams": {
+                            "data": {
+                                "fields": [
+                                    "time",
+                                    "appName",
+                                    "appUser",
+                                    "logicalOperatorName",
+                                    "eventsReadPerSecond:SUM",
+                                    "eventsReadPerSecond:MIN",
+                                    "eventsReadPerSecond:MAX",
+                                    "eventsReadPerSecond:COUNT",
+                                    "eventsReadPerSecond:FIRST",
+                                    "eventsReadPerSecond:LAST",
+                                    "eventsReadPerSecond:AVG"
+                                ],
+                                "incompleteResultOK": true,
+                                "keys": {
+                                    "appName": [
+                                        "Database-to-Database-Sync"
+                                    ],
+                                    "appUser": [
+                                        "deepak"
+                                    ],
+                                    "logicalOperatorName": [
+                                        "JdbcInput"
+                                    ]
+                                },
+                                "time": {
+                                    "bucket": "1m",
+                                    "latestNumBuckets": "10"
+                                }
+                            },
+                            "dimensionId": "0",
+                            "getDataContinuously": true,
+                            "incompleteResultOK": true,
+                            "rangeType": "latestNumBuckets"
+                        },
+                        "dataSource": {
+                            "appName": "Database-to-Database-Sync",
+                            "appPackageSource": {
+                                "appName": "Database-to-Database-Sync",
+                                "name": "database-to-database-sync",
+                                "user": "deepak",
+                                "version": "0.9.0"
+                            },
+                            "appUser": "deepak",
+                            "context": {
+                                "keys": {
+                                    "appName": "Database-to-Database-Sync",
+                                    "appUser": "deepak",
+                                    "logicalOperatorName": "JdbcInput"
+                                }
+                            },
+                            "displayName": "Historical :: Operator Metrics : JdbcInput (user: deepak; app: Database-to-Database-Sync)",
+                            "name": "Historical :: Operator Metrics : JdbcInput",
+                            "query": {
+                                "operatorName": "MetricsStore.query",
+                                "topic": "DTMetricsHistQuery",
+                                "url": "pubsub"
+                            },
+                            "result": {
+                                "appendQIDToTopic": true,
+                                "operatorName": "MetricsResult",
+                                "topic": "DTMetricsHistResult",
+                                "url": "pubsub"
+                            },
+                            "type": "metrics"
+                        },
+                        "keysRequiringValues": [],
+                        "loadingData": false,
+                        "schema": {
+                            "currentValues": [
+                                {
+                                    "name": "eventsReadPerSecond:SUM",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "eventsReadPerSecond:MIN",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "eventsReadPerSecond:MAX",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "eventsReadPerSecond:COUNT",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "eventsReadPerSecond:FIRST",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "eventsReadPerSecond:LAST",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "eventsReadPerSecond:AVG",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "totalEventsRead:SUM",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "totalEventsRead:MIN",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "totalEventsRead:MAX",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "totalEventsRead:COUNT",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "totalEventsRead:FIRST",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "totalEventsRead:LAST",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "totalEventsRead:AVG",
+                                    "type": "long"
+                                }
+                            ],
+                            "dimensions": [
+                                {
+                                    "additionalValues": [
+                                        {
+                                            "name": "eventsReadPerSecond:SUM",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "eventsReadPerSecond:MIN",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "eventsReadPerSecond:MAX",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "eventsReadPerSecond:COUNT",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "eventsReadPerSecond:FIRST",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "eventsReadPerSecond:LAST",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "eventsReadPerSecond:AVG",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "totalEventsRead:SUM",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "totalEventsRead:MIN",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "totalEventsRead:MAX",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "totalEventsRead:COUNT",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "totalEventsRead:FIRST",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "totalEventsRead:LAST",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "totalEventsRead:AVG",
+                                            "type": "long"
+                                        }
+                                    ],
+                                    "combination": [
+                                        "appName",
+                                        "appUser",
+                                        "logicalOperatorName"
+                                    ],
+                                    "id": "0",
+                                    "label": "appName, appUser, logicalOperatorName",
+                                    "valueFields": [
+                                        {
+                                            "category": "eventsReadPerSecond",
+                                            "filter": "number",
+                                            "id": "eventsReadPerSecond:SUM",
+                                            "key": "eventsReadPerSecond:SUM",
+                                            "selected": true,
+                                            "sort": "number",
+                                            "subcategory": "SUM",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "eventsReadPerSecond",
+                                            "filter": "number",
+                                            "id": "eventsReadPerSecond:MIN",
+                                            "key": "eventsReadPerSecond:MIN",
+                                            "selected": true,
+                                            "sort": "number",
+                                            "subcategory": "MIN",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "eventsReadPerSecond",
+                                            "filter": "number",
+                                            "id": "eventsReadPerSecond:MAX",
+                                            "key": "eventsReadPerSecond:MAX",
+                                            "selected": true,
+                                            "sort": "number",
+                                            "subcategory": "MAX",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "eventsReadPerSecond",
+                                            "filter": "number",
+                                            "id": "eventsReadPerSecond:COUNT",
+                                            "key": "eventsReadPerSecond:COUNT",
+                                            "selected": true,
+                                            "sort": "number",
+                                            "subcategory": "COUNT",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "eventsReadPerSecond",
+                                            "filter": "number",
+                                            "id": "eventsReadPerSecond:FIRST",
+                                            "key": "eventsReadPerSecond:FIRST",
+                                            "selected": true,
+                                            "sort": "number",
+                                            "subcategory": "FIRST",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "eventsReadPerSecond",
+                                            "filter": "number",
+                                            "id": "eventsReadPerSecond:LAST",
+                                            "key": "eventsReadPerSecond:LAST",
+                                            "selected": true,
+                                            "sort": "number",
+                                            "subcategory": "LAST",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "eventsReadPerSecond",
+                                            "filter": "number",
+                                            "id": "eventsReadPerSecond:AVG",
+                                            "key": "eventsReadPerSecond:AVG",
+                                            "selected": true,
+                                            "sort": "number",
+                                            "subcategory": "AVG",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "totalEventsRead",
+                                            "filter": "number",
+                                            "id": "totalEventsRead:SUM",
+                                            "key": "totalEventsRead:SUM",
+                                            "selected": false,
+                                            "sort": "number",
+                                            "subcategory": "SUM",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "totalEventsRead",
+                                            "filter": "number",
+                                            "id": "totalEventsRead:MIN",
+                                            "key": "totalEventsRead:MIN",
+                                            "selected": false,
+                                            "sort": "number",
+                                            "subcategory": "MIN",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "totalEventsRead",
+                                            "filter": "number",
+                                            "id": "totalEventsRead:MAX",
+                                            "key": "totalEventsRead:MAX",
+                                            "selected": false,
+                                            "sort": "number",
+                                            "subcategory": "MAX",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "totalEventsRead",
+                                            "filter": "number",
+                                            "id": "totalEventsRead:COUNT",
+                                            "key": "totalEventsRead:COUNT",
+                                            "selected": false,
+                                            "sort": "number",
+                                            "subcategory": "COUNT",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "totalEventsRead",
+                                            "filter": "number",
+                                            "id": "totalEventsRead:FIRST",
+                                            "key": "totalEventsRead:FIRST",
+                                            "selected": false,
+                                            "sort": "number",
+                                            "subcategory": "FIRST",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "totalEventsRead",
+                                            "filter": "number",
+                                            "id": "totalEventsRead:LAST",
+                                            "key": "totalEventsRead:LAST",
+                                            "selected": false,
+                                            "sort": "number",
+                                            "subcategory": "LAST",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "totalEventsRead",
+                                            "filter": "number",
+                                            "id": "totalEventsRead:AVG",
+                                            "key": "totalEventsRead:AVG",
+                                            "selected": false,
+                                            "sort": "number",
+                                            "subcategory": "AVG",
+                                            "type": "long"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "fieldSelectionColumns": [
+                                {
+                                    "id": "selector",
+                                    "key": "id",
+                                    "label": "",
+                                    "lockWidth": true,
+                                    "selector": true,
+                                    "width": "40px"
+                                },
+                                {
+                                    "filter": "like",
+                                    "id": "id",
+                                    "key": "id",
+                                    "sort": "string"
+                                },
+                                {
+                                    "filter": "like",
+                                    "id": "type",
+                                    "key": "type",
+                                    "sort": "string"
+                                }
+                            ],
+                            "fieldSelectionOptions": {
+                                "bgSizeMultiplier": "2",
+                                "defaultRowHeight": "29",
+                                "initialSorts": [
+                                    {
+                                        "dir": "+",
+                                        "id": "id"
+                                    }
+                                ],
+                                "loading": false
+                            },
+                            "fields": [
+                                {
+                                    "filter": "date",
+                                    "id": "time",
+                                    "key": "time",
+                                    "ngFilter": "date:'yyyy-MM-dd HH:mm:ss Z'",
+                                    "sort": "number",
+                                    "type": "date"
+                                },
+                                {
+                                    "filter": "like",
+                                    "id": "appName",
+                                    "key": "appName",
+                                    "sort": "string",
+                                    "type": "string"
+                                },
+                                {
+                                    "filter": "like",
+                                    "id": "appUser",
+                                    "key": "appUser",
+                                    "sort": "string",
+                                    "type": "string"
+                                },
+                                {
+                                    "filter": "like",
+                                    "id": "logicalOperatorName",
+                                    "key": "logicalOperatorName",
+                                    "sort": "string",
+                                    "type": "string"
+                                }
+                            ],
+                            "fieldsAllDimensions": [
+                                {
+                                    "filter": "date",
+                                    "id": "time",
+                                    "key": "time",
+                                    "ngFilter": "date:'yyyy-MM-dd HH:mm:ss Z'",
+                                    "sort": "number",
+                                    "type": "date"
+                                },
+                                {
+                                    "filter": "like",
+                                    "id": "appName",
+                                    "key": "appName",
+                                    "sort": "string",
+                                    "type": "string"
+                                },
+                                {
+                                    "filter": "like",
+                                    "id": "appUser",
+                                    "key": "appUser",
+                                    "sort": "string",
+                                    "type": "string"
+                                },
+                                {
+                                    "filter": "like",
+                                    "id": "logicalOperatorName",
+                                    "key": "logicalOperatorName",
+                                    "sort": "string",
+                                    "type": "string"
+                                },
+                                {
+                                    "category": "eventsReadPerSecond",
+                                    "filter": "number",
+                                    "id": "eventsReadPerSecond:SUM",
+                                    "key": "eventsReadPerSecond:SUM",
+                                    "selected": true,
+                                    "sort": "number",
+                                    "subcategory": "SUM",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "eventsReadPerSecond",
+                                    "filter": "number",
+                                    "id": "eventsReadPerSecond:MIN",
+                                    "key": "eventsReadPerSecond:MIN",
+                                    "selected": true,
+                                    "sort": "number",
+                                    "subcategory": "MIN",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "eventsReadPerSecond",
+                                    "filter": "number",
+                                    "id": "eventsReadPerSecond:MAX",
+                                    "key": "eventsReadPerSecond:MAX",
+                                    "selected": true,
+                                    "sort": "number",
+                                    "subcategory": "MAX",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "eventsReadPerSecond",
+                                    "filter": "number",
+                                    "id": "eventsReadPerSecond:COUNT",
+                                    "key": "eventsReadPerSecond:COUNT",
+                                    "selected": true,
+                                    "sort": "number",
+                                    "subcategory": "COUNT",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "eventsReadPerSecond",
+                                    "filter": "number",
+                                    "id": "eventsReadPerSecond:FIRST",
+                                    "key": "eventsReadPerSecond:FIRST",
+                                    "selected": true,
+                                    "sort": "number",
+                                    "subcategory": "FIRST",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "eventsReadPerSecond",
+                                    "filter": "number",
+                                    "id": "eventsReadPerSecond:LAST",
+                                    "key": "eventsReadPerSecond:LAST",
+                                    "selected": true,
+                                    "sort": "number",
+                                    "subcategory": "LAST",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "eventsReadPerSecond",
+                                    "filter": "number",
+                                    "id": "eventsReadPerSecond:AVG",
+                                    "key": "eventsReadPerSecond:AVG",
+                                    "selected": true,
+                                    "sort": "number",
+                                    "subcategory": "AVG",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "totalEventsRead",
+                                    "filter": "number",
+                                    "id": "totalEventsRead:SUM",
+                                    "key": "totalEventsRead:SUM",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "SUM",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "totalEventsRead",
+                                    "filter": "number",
+                                    "id": "totalEventsRead:MIN",
+                                    "key": "totalEventsRead:MIN",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "MIN",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "totalEventsRead",
+                                    "filter": "number",
+                                    "id": "totalEventsRead:MAX",
+                                    "key": "totalEventsRead:MAX",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "MAX",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "totalEventsRead",
+                                    "filter": "number",
+                                    "id": "totalEventsRead:COUNT",
+                                    "key": "totalEventsRead:COUNT",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "COUNT",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "totalEventsRead",
+                                    "filter": "number",
+                                    "id": "totalEventsRead:FIRST",
+                                    "key": "totalEventsRead:FIRST",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "FIRST",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "totalEventsRead",
+                                    "filter": "number",
+                                    "id": "totalEventsRead:LAST",
+                                    "key": "totalEventsRead:LAST",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "LAST",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "totalEventsRead",
+                                    "filter": "number",
+                                    "id": "totalEventsRead:AVG",
+                                    "key": "totalEventsRead:AVG",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "AVG",
+                                    "type": "long"
+                                }
+                            ],
+                            "keyFields": [
+                                {
+                                    "filter": "like",
+                                    "id": "appName",
+                                    "key": "appName",
+                                    "sort": "string",
+                                    "type": "string"
+                                },
+                                {
+                                    "filter": "like",
+                                    "id": "appUser",
+                                    "key": "appUser",
+                                    "sort": "string",
+                                    "type": "string"
+                                },
+                                {
+                                    "filter": "like",
+                                    "id": "logicalOperatorName",
+                                    "key": "logicalOperatorName",
+                                    "sort": "string",
+                                    "type": "string"
+                                }
+                            ],
+                            "keys": [
+                                {
+                                    "enumValues": [
+                                        "Database-to-Database-Sync"
+                                    ],
+                                    "name": "appName",
+                                    "type": "string"
+                                },
+                                {
+                                    "enumValues": [
+                                        "deepak"
+                                    ],
+                                    "name": "appUser",
+                                    "type": "string"
+                                },
+                                {
+                                    "enumValues": [
+                                        "JdbcInput"
+                                    ],
+                                    "name": "logicalOperatorName",
+                                    "type": "string"
+                                }
+                            ],
+                            "schemaType": "dimensions",
+                            "schemaVersion": "1.0",
+                            "time": {
+                                "buckets": [
+                                    "1m",
+                                    "1h",
+                                    "1d"
+                                ],
+                                "slidingAggregateSupported": true
+                            },
+                            "timeFields": [
+                                {
+                                    "filter": "date",
+                                    "id": "time",
+                                    "key": "time",
+                                    "ngFilter": "date:'yyyy-MM-dd HH:mm:ss Z'",
+                                    "sort": "number",
+                                    "type": "date"
+                                }
+                            ],
+                            "valueFields": [],
+                            "valueFieldsAllDimensions": [
+                                {
+                                    "category": "eventsReadPerSecond",
+                                    "filter": "number",
+                                    "id": "eventsReadPerSecond:SUM",
+                                    "key": "eventsReadPerSecond:SUM",
+                                    "selected": true,
+                                    "sort": "number",
+                                    "subcategory": "SUM",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "eventsReadPerSecond",
+                                    "filter": "number",
+                                    "id": "eventsReadPerSecond:MIN",
+                                    "key": "eventsReadPerSecond:MIN",
+                                    "selected": true,
+                                    "sort": "number",
+                                    "subcategory": "MIN",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "eventsReadPerSecond",
+                                    "filter": "number",
+                                    "id": "eventsReadPerSecond:MAX",
+                                    "key": "eventsReadPerSecond:MAX",
+                                    "selected": true,
+                                    "sort": "number",
+                                    "subcategory": "MAX",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "eventsReadPerSecond",
+                                    "filter": "number",
+                                    "id": "eventsReadPerSecond:COUNT",
+                                    "key": "eventsReadPerSecond:COUNT",
+                                    "selected": true,
+                                    "sort": "number",
+                                    "subcategory": "COUNT",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "eventsReadPerSecond",
+                                    "filter": "number",
+                                    "id": "eventsReadPerSecond:FIRST",
+                                    "key": "eventsReadPerSecond:FIRST",
+                                    "selected": true,
+                                    "sort": "number",
+                                    "subcategory": "FIRST",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "eventsReadPerSecond",
+                                    "filter": "number",
+                                    "id": "eventsReadPerSecond:LAST",
+                                    "key": "eventsReadPerSecond:LAST",
+                                    "selected": true,
+                                    "sort": "number",
+                                    "subcategory": "LAST",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "eventsReadPerSecond",
+                                    "filter": "number",
+                                    "id": "eventsReadPerSecond:AVG",
+                                    "key": "eventsReadPerSecond:AVG",
+                                    "selected": true,
+                                    "sort": "number",
+                                    "subcategory": "AVG",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "totalEventsRead",
+                                    "filter": "number",
+                                    "id": "totalEventsRead:SUM",
+                                    "key": "totalEventsRead:SUM",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "SUM",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "totalEventsRead",
+                                    "filter": "number",
+                                    "id": "totalEventsRead:MIN",
+                                    "key": "totalEventsRead:MIN",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "MIN",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "totalEventsRead",
+                                    "filter": "number",
+                                    "id": "totalEventsRead:MAX",
+                                    "key": "totalEventsRead:MAX",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "MAX",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "totalEventsRead",
+                                    "filter": "number",
+                                    "id": "totalEventsRead:COUNT",
+                                    "key": "totalEventsRead:COUNT",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "COUNT",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "totalEventsRead",
+                                    "filter": "number",
+                                    "id": "totalEventsRead:FIRST",
+                                    "key": "totalEventsRead:FIRST",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "FIRST",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "totalEventsRead",
+                                    "filter": "number",
+                                    "id": "totalEventsRead:LAST",
+                                    "key": "totalEventsRead:LAST",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "LAST",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "totalEventsRead",
+                                    "filter": "number",
+                                    "id": "totalEventsRead:AVG",
+                                    "key": "totalEventsRead:AVG",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "AVG",
+                                    "type": "long"
+                                }
+                            ],
+                            "values": []
+                        },
+                        "tags": {
+                            "multiKeySelect": true
+                        }
+                    },
+                    "name": "line chart",
+                    "size": {
+                        "contentOverflow": "hidden",
+                        "minHeight": "300px",
+                        "minWidth": "500px",
+                        "width": "50%"
+                    },
+                    "style": {},
+                    "title": "Line Chart"
+                },
+                {
+                    "dataModelOptions": {
+                        "allowFetchData": true,
+                        "dataQueryParams": {
+                            "data": {
+                                "fields": [
+                                    "time",
+                                    "appName",
+                                    "appUser",
+                                    "logicalOperatorName",
+                                    "eventsWrittenPerSecond:SUM",
+                                    "eventsWrittenPerSecond:MIN",
+                                    "eventsWrittenPerSecond:MAX",
+                                    "eventsWrittenPerSecond:COUNT",
+                                    "eventsWrittenPerSecond:FIRST",
+                                    "eventsWrittenPerSecond:LAST",
+                                    "eventsWrittenPerSecond:AVG"
+                                ],
+                                "incompleteResultOK": true,
+                                "keys": {
+                                    "appName": [
+                                        "Database-to-Database-Sync"
+                                    ],
+                                    "appUser": [
+                                        "deepak"
+                                    ],
+                                    "logicalOperatorName": [
+                                        "JdbcOutput"
+                                    ]
+                                },
+                                "time": {
+                                    "bucket": "1m",
+                                    "latestNumBuckets": "10"
+                                }
+                            },
+                            "dimensionId": "0",
+                            "getDataContinuously": true,
+                            "incompleteResultOK": true,
+                            "rangeType": "latestNumBuckets"
+                        },
+                        "dataSource": {
+                            "appName": "Database-to-Database-Sync",
+                            "appPackageSource": {
+                                "appName": "Database-to-Database-Sync",
+                                "name": "database-to-database-sync",
+                                "user": "deepak",
+                                "version": "0.9.0"
+                            },
+                            "appUser": "deepak",
+                            "context": {
+                                "keys": {
+                                    "appName": "Database-to-Database-Sync",
+                                    "appUser": "deepak",
+                                    "logicalOperatorName": "JdbcOutput"
+                                }
+                            },
+                            "displayName": "Historical :: Operator Metrics : JdbcOutput (user: deepak; app: Database-to-Database-Sync)",
+                            "name": "Historical :: Operator Metrics : JdbcOutput",
+                            "query": {
+                                "operatorName": "MetricsStore.query",
+                                "topic": "DTMetricsHistQuery",
+                                "url": "pubsub"
+                            },
+                            "result": {
+                                "appendQIDToTopic": true,
+                                "operatorName": "MetricsResult",
+                                "topic": "DTMetricsHistResult",
+                                "url": "pubsub"
+                            },
+                            "type": "metrics"
+                        },
+                        "keysRequiringValues": [],
+                        "loadingData": false,
+                        "schema": {
+                            "currentValues": [
+                                {
+                                    "name": "eventsWrittenPerSecond:SUM",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "eventsWrittenPerSecond:MIN",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "eventsWrittenPerSecond:MAX",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "eventsWrittenPerSecond:COUNT",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "eventsWrittenPerSecond:FIRST",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "eventsWrittenPerSecond:LAST",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "eventsWrittenPerSecond:AVG",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "totalEventsWritten:SUM",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "totalEventsWritten:MIN",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "totalEventsWritten:MAX",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "totalEventsWritten:COUNT",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "totalEventsWritten:FIRST",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "totalEventsWritten:LAST",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "totalEventsWritten:AVG",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "errorTuples:SUM",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "errorTuples:MIN",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "errorTuples:MAX",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "errorTuples:COUNT",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "errorTuples:FIRST",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "errorTuples:LAST",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "errorTuples:AVG",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "totalBadEvents:SUM",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "totalBadEvents:MIN",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "totalBadEvents:MAX",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "totalBadEvents:COUNT",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "totalBadEvents:FIRST",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "totalBadEvents:LAST",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "totalBadEvents:AVG",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "tuplesWrittenSuccessfully:SUM",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "tuplesWrittenSuccessfully:MIN",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "tuplesWrittenSuccessfully:MAX",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "tuplesWrittenSuccessfully:COUNT",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "tuplesWrittenSuccessfully:FIRST",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "tuplesWrittenSuccessfully:LAST",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "tuplesWrittenSuccessfully:AVG",
+                                    "type": "long"
+                                }
+                            ],
+                            "dimensions": [
+                                {
+                                    "additionalValues": [
+                                        {
+                                            "name": "eventsWrittenPerSecond:SUM",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "eventsWrittenPerSecond:MIN",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "eventsWrittenPerSecond:MAX",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "eventsWrittenPerSecond:COUNT",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "eventsWrittenPerSecond:FIRST",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "eventsWrittenPerSecond:LAST",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "eventsWrittenPerSecond:AVG",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "totalEventsWritten:SUM",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "totalEventsWritten:MIN",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "totalEventsWritten:MAX",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "totalEventsWritten:COUNT",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "totalEventsWritten:FIRST",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "totalEventsWritten:LAST",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "totalEventsWritten:AVG",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "errorTuples:SUM",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "errorTuples:MIN",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "errorTuples:MAX",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "errorTuples:COUNT",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "errorTuples:FIRST",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "errorTuples:LAST",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "errorTuples:AVG",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "totalBadEvents:SUM",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "totalBadEvents:MIN",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "totalBadEvents:MAX",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "totalBadEvents:COUNT",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "totalBadEvents:FIRST",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "totalBadEvents:LAST",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "totalBadEvents:AVG",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "tuplesWrittenSuccessfully:SUM",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "tuplesWrittenSuccessfully:MIN",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "tuplesWrittenSuccessfully:MAX",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "tuplesWrittenSuccessfully:COUNT",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "tuplesWrittenSuccessfully:FIRST",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "tuplesWrittenSuccessfully:LAST",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "name": "tuplesWrittenSuccessfully:AVG",
+                                            "type": "long"
+                                        }
+                                    ],
+                                    "combination": [
+                                        "appName",
+                                        "appUser",
+                                        "logicalOperatorName"
+                                    ],
+                                    "id": "0",
+                                    "label": "appName, appUser, logicalOperatorName",
+                                    "valueFields": [
+                                        {
+                                            "category": "eventsWrittenPerSecond",
+                                            "filter": "number",
+                                            "id": "eventsWrittenPerSecond:SUM",
+                                            "key": "eventsWrittenPerSecond:SUM",
+                                            "selected": true,
+                                            "sort": "number",
+                                            "subcategory": "SUM",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "eventsWrittenPerSecond",
+                                            "filter": "number",
+                                            "id": "eventsWrittenPerSecond:MIN",
+                                            "key": "eventsWrittenPerSecond:MIN",
+                                            "selected": true,
+                                            "sort": "number",
+                                            "subcategory": "MIN",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "eventsWrittenPerSecond",
+                                            "filter": "number",
+                                            "id": "eventsWrittenPerSecond:MAX",
+                                            "key": "eventsWrittenPerSecond:MAX",
+                                            "selected": true,
+                                            "sort": "number",
+                                            "subcategory": "MAX",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "eventsWrittenPerSecond",
+                                            "filter": "number",
+                                            "id": "eventsWrittenPerSecond:COUNT",
+                                            "key": "eventsWrittenPerSecond:COUNT",
+                                            "selected": true,
+                                            "sort": "number",
+                                            "subcategory": "COUNT",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "eventsWrittenPerSecond",
+                                            "filter": "number",
+                                            "id": "eventsWrittenPerSecond:FIRST",
+                                            "key": "eventsWrittenPerSecond:FIRST",
+                                            "selected": true,
+                                            "sort": "number",
+                                            "subcategory": "FIRST",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "eventsWrittenPerSecond",
+                                            "filter": "number",
+                                            "id": "eventsWrittenPerSecond:LAST",
+                                            "key": "eventsWrittenPerSecond:LAST",
+                                            "selected": true,
+                                            "sort": "number",
+                                            "subcategory": "LAST",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "eventsWrittenPerSecond",
+                                            "filter": "number",
+                                            "id": "eventsWrittenPerSecond:AVG",
+                                            "key": "eventsWrittenPerSecond:AVG",
+                                            "selected": true,
+                                            "sort": "number",
+                                            "subcategory": "AVG",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "totalEventsWritten",
+                                            "filter": "number",
+                                            "id": "totalEventsWritten:SUM",
+                                            "key": "totalEventsWritten:SUM",
+                                            "selected": false,
+                                            "sort": "number",
+                                            "subcategory": "SUM",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "totalEventsWritten",
+                                            "filter": "number",
+                                            "id": "totalEventsWritten:MIN",
+                                            "key": "totalEventsWritten:MIN",
+                                            "selected": false,
+                                            "sort": "number",
+                                            "subcategory": "MIN",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "totalEventsWritten",
+                                            "filter": "number",
+                                            "id": "totalEventsWritten:MAX",
+                                            "key": "totalEventsWritten:MAX",
+                                            "selected": false,
+                                            "sort": "number",
+                                            "subcategory": "MAX",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "totalEventsWritten",
+                                            "filter": "number",
+                                            "id": "totalEventsWritten:COUNT",
+                                            "key": "totalEventsWritten:COUNT",
+                                            "selected": false,
+                                            "sort": "number",
+                                            "subcategory": "COUNT",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "totalEventsWritten",
+                                            "filter": "number",
+                                            "id": "totalEventsWritten:FIRST",
+                                            "key": "totalEventsWritten:FIRST",
+                                            "selected": false,
+                                            "sort": "number",
+                                            "subcategory": "FIRST",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "totalEventsWritten",
+                                            "filter": "number",
+                                            "id": "totalEventsWritten:LAST",
+                                            "key": "totalEventsWritten:LAST",
+                                            "selected": false,
+                                            "sort": "number",
+                                            "subcategory": "LAST",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "totalEventsWritten",
+                                            "filter": "number",
+                                            "id": "totalEventsWritten:AVG",
+                                            "key": "totalEventsWritten:AVG",
+                                            "selected": false,
+                                            "sort": "number",
+                                            "subcategory": "AVG",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "errorTuples",
+                                            "filter": "number",
+                                            "id": "errorTuples:SUM",
+                                            "key": "errorTuples:SUM",
+                                            "selected": false,
+                                            "sort": "number",
+                                            "subcategory": "SUM",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "errorTuples",
+                                            "filter": "number",
+                                            "id": "errorTuples:MIN",
+                                            "key": "errorTuples:MIN",
+                                            "selected": false,
+                                            "sort": "number",
+                                            "subcategory": "MIN",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "errorTuples",
+                                            "filter": "number",
+                                            "id": "errorTuples:MAX",
+                                            "key": "errorTuples:MAX",
+                                            "selected": false,
+                                            "sort": "number",
+                                            "subcategory": "MAX",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "errorTuples",
+                                            "filter": "number",
+                                            "id": "errorTuples:COUNT",
+                                            "key": "errorTuples:COUNT",
+                                            "selected": false,
+                                            "sort": "number",
+                                            "subcategory": "COUNT",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "errorTuples",
+                                            "filter": "number",
+                                            "id": "errorTuples:FIRST",
+                                            "key": "errorTuples:FIRST",
+                                            "selected": false,
+                                            "sort": "number",
+                                            "subcategory": "FIRST",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "errorTuples",
+                                            "filter": "number",
+                                            "id": "errorTuples:LAST",
+                                            "key": "errorTuples:LAST",
+                                            "selected": false,
+                                            "sort": "number",
+                                            "subcategory": "LAST",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "errorTuples",
+                                            "filter": "number",
+                                            "id": "errorTuples:AVG",
+                                            "key": "errorTuples:AVG",
+                                            "selected": false,
+                                            "sort": "number",
+                                            "subcategory": "AVG",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "totalBadEvents",
+                                            "filter": "number",
+                                            "id": "totalBadEvents:SUM",
+                                            "key": "totalBadEvents:SUM",
+                                            "selected": false,
+                                            "sort": "number",
+                                            "subcategory": "SUM",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "totalBadEvents",
+                                            "filter": "number",
+                                            "id": "totalBadEvents:MIN",
+                                            "key": "totalBadEvents:MIN",
+                                            "selected": false,
+                                            "sort": "number",
+                                            "subcategory": "MIN",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "totalBadEvents",
+                                            "filter": "number",
+                                            "id": "totalBadEvents:MAX",
+                                            "key": "totalBadEvents:MAX",
+                                            "selected": false,
+                                            "sort": "number",
+                                            "subcategory": "MAX",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "totalBadEvents",
+                                            "filter": "number",
+                                            "id": "totalBadEvents:COUNT",
+                                            "key": "totalBadEvents:COUNT",
+                                            "selected": false,
+                                            "sort": "number",
+                                            "subcategory": "COUNT",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "totalBadEvents",
+                                            "filter": "number",
+                                            "id": "totalBadEvents:FIRST",
+                                            "key": "totalBadEvents:FIRST",
+                                            "selected": false,
+                                            "sort": "number",
+                                            "subcategory": "FIRST",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "totalBadEvents",
+                                            "filter": "number",
+                                            "id": "totalBadEvents:LAST",
+                                            "key": "totalBadEvents:LAST",
+                                            "selected": false,
+                                            "sort": "number",
+                                            "subcategory": "LAST",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "totalBadEvents",
+                                            "filter": "number",
+                                            "id": "totalBadEvents:AVG",
+                                            "key": "totalBadEvents:AVG",
+                                            "selected": false,
+                                            "sort": "number",
+                                            "subcategory": "AVG",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "tuplesWrittenSuccessfully",
+                                            "filter": "number",
+                                            "id": "tuplesWrittenSuccessfully:SUM",
+                                            "key": "tuplesWrittenSuccessfully:SUM",
+                                            "selected": false,
+                                            "sort": "number",
+                                            "subcategory": "SUM",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "tuplesWrittenSuccessfully",
+                                            "filter": "number",
+                                            "id": "tuplesWrittenSuccessfully:MIN",
+                                            "key": "tuplesWrittenSuccessfully:MIN",
+                                            "selected": false,
+                                            "sort": "number",
+                                            "subcategory": "MIN",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "tuplesWrittenSuccessfully",
+                                            "filter": "number",
+                                            "id": "tuplesWrittenSuccessfully:MAX",
+                                            "key": "tuplesWrittenSuccessfully:MAX",
+                                            "selected": false,
+                                            "sort": "number",
+                                            "subcategory": "MAX",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "tuplesWrittenSuccessfully",
+                                            "filter": "number",
+                                            "id": "tuplesWrittenSuccessfully:COUNT",
+                                            "key": "tuplesWrittenSuccessfully:COUNT",
+                                            "selected": false,
+                                            "sort": "number",
+                                            "subcategory": "COUNT",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "tuplesWrittenSuccessfully",
+                                            "filter": "number",
+                                            "id": "tuplesWrittenSuccessfully:FIRST",
+                                            "key": "tuplesWrittenSuccessfully:FIRST",
+                                            "selected": false,
+                                            "sort": "number",
+                                            "subcategory": "FIRST",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "tuplesWrittenSuccessfully",
+                                            "filter": "number",
+                                            "id": "tuplesWrittenSuccessfully:LAST",
+                                            "key": "tuplesWrittenSuccessfully:LAST",
+                                            "selected": false,
+                                            "sort": "number",
+                                            "subcategory": "LAST",
+                                            "type": "long"
+                                        },
+                                        {
+                                            "category": "tuplesWrittenSuccessfully",
+                                            "filter": "number",
+                                            "id": "tuplesWrittenSuccessfully:AVG",
+                                            "key": "tuplesWrittenSuccessfully:AVG",
+                                            "selected": false,
+                                            "sort": "number",
+                                            "subcategory": "AVG",
+                                            "type": "long"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "fieldSelectionColumns": [
+                                {
+                                    "id": "selector",
+                                    "key": "id",
+                                    "label": "",
+                                    "lockWidth": true,
+                                    "selector": true,
+                                    "width": "40px"
+                                },
+                                {
+                                    "filter": "like",
+                                    "id": "id",
+                                    "key": "id",
+                                    "sort": "string"
+                                },
+                                {
+                                    "filter": "like",
+                                    "id": "type",
+                                    "key": "type",
+                                    "sort": "string"
+                                }
+                            ],
+                            "fieldSelectionOptions": {
+                                "bgSizeMultiplier": "2",
+                                "defaultRowHeight": "29",
+                                "initialSorts": [
+                                    {
+                                        "dir": "+",
+                                        "id": "id"
+                                    }
+                                ],
+                                "loading": false
+                            },
+                            "fields": [
+                                {
+                                    "filter": "date",
+                                    "id": "time",
+                                    "key": "time",
+                                    "ngFilter": "date:'yyyy-MM-dd HH:mm:ss Z'",
+                                    "sort": "number",
+                                    "type": "date"
+                                },
+                                {
+                                    "filter": "like",
+                                    "id": "appName",
+                                    "key": "appName",
+                                    "sort": "string",
+                                    "type": "string"
+                                },
+                                {
+                                    "filter": "like",
+                                    "id": "appUser",
+                                    "key": "appUser",
+                                    "sort": "string",
+                                    "type": "string"
+                                },
+                                {
+                                    "filter": "like",
+                                    "id": "logicalOperatorName",
+                                    "key": "logicalOperatorName",
+                                    "sort": "string",
+                                    "type": "string"
+                                }
+                            ],
+                            "fieldsAllDimensions": [
+                                {
+                                    "filter": "date",
+                                    "id": "time",
+                                    "key": "time",
+                                    "ngFilter": "date:'yyyy-MM-dd HH:mm:ss Z'",
+                                    "sort": "number",
+                                    "type": "date"
+                                },
+                                {
+                                    "filter": "like",
+                                    "id": "appName",
+                                    "key": "appName",
+                                    "sort": "string",
+                                    "type": "string"
+                                },
+                                {
+                                    "filter": "like",
+                                    "id": "appUser",
+                                    "key": "appUser",
+                                    "sort": "string",
+                                    "type": "string"
+                                },
+                                {
+                                    "filter": "like",
+                                    "id": "logicalOperatorName",
+                                    "key": "logicalOperatorName",
+                                    "sort": "string",
+                                    "type": "string"
+                                },
+                                {
+                                    "category": "eventsWrittenPerSecond",
+                                    "filter": "number",
+                                    "id": "eventsWrittenPerSecond:SUM",
+                                    "key": "eventsWrittenPerSecond:SUM",
+                                    "selected": true,
+                                    "sort": "number",
+                                    "subcategory": "SUM",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "eventsWrittenPerSecond",
+                                    "filter": "number",
+                                    "id": "eventsWrittenPerSecond:MIN",
+                                    "key": "eventsWrittenPerSecond:MIN",
+                                    "selected": true,
+                                    "sort": "number",
+                                    "subcategory": "MIN",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "eventsWrittenPerSecond",
+                                    "filter": "number",
+                                    "id": "eventsWrittenPerSecond:MAX",
+                                    "key": "eventsWrittenPerSecond:MAX",
+                                    "selected": true,
+                                    "sort": "number",
+                                    "subcategory": "MAX",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "eventsWrittenPerSecond",
+                                    "filter": "number",
+                                    "id": "eventsWrittenPerSecond:COUNT",
+                                    "key": "eventsWrittenPerSecond:COUNT",
+                                    "selected": true,
+                                    "sort": "number",
+                                    "subcategory": "COUNT",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "eventsWrittenPerSecond",
+                                    "filter": "number",
+                                    "id": "eventsWrittenPerSecond:FIRST",
+                                    "key": "eventsWrittenPerSecond:FIRST",
+                                    "selected": true,
+                                    "sort": "number",
+                                    "subcategory": "FIRST",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "eventsWrittenPerSecond",
+                                    "filter": "number",
+                                    "id": "eventsWrittenPerSecond:LAST",
+                                    "key": "eventsWrittenPerSecond:LAST",
+                                    "selected": true,
+                                    "sort": "number",
+                                    "subcategory": "LAST",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "eventsWrittenPerSecond",
+                                    "filter": "number",
+                                    "id": "eventsWrittenPerSecond:AVG",
+                                    "key": "eventsWrittenPerSecond:AVG",
+                                    "selected": true,
+                                    "sort": "number",
+                                    "subcategory": "AVG",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "totalEventsWritten",
+                                    "filter": "number",
+                                    "id": "totalEventsWritten:SUM",
+                                    "key": "totalEventsWritten:SUM",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "SUM",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "totalEventsWritten",
+                                    "filter": "number",
+                                    "id": "totalEventsWritten:MIN",
+                                    "key": "totalEventsWritten:MIN",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "MIN",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "totalEventsWritten",
+                                    "filter": "number",
+                                    "id": "totalEventsWritten:MAX",
+                                    "key": "totalEventsWritten:MAX",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "MAX",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "totalEventsWritten",
+                                    "filter": "number",
+                                    "id": "totalEventsWritten:COUNT",
+                                    "key": "totalEventsWritten:COUNT",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "COUNT",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "totalEventsWritten",
+                                    "filter": "number",
+                                    "id": "totalEventsWritten:FIRST",
+                                    "key": "totalEventsWritten:FIRST",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "FIRST",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "totalEventsWritten",
+                                    "filter": "number",
+                                    "id": "totalEventsWritten:LAST",
+                                    "key": "totalEventsWritten:LAST",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "LAST",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "totalEventsWritten",
+                                    "filter": "number",
+                                    "id": "totalEventsWritten:AVG",
+                                    "key": "totalEventsWritten:AVG",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "AVG",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "errorTuples",
+                                    "filter": "number",
+                                    "id": "errorTuples:SUM",
+                                    "key": "errorTuples:SUM",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "SUM",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "errorTuples",
+                                    "filter": "number",
+                                    "id": "errorTuples:MIN",
+                                    "key": "errorTuples:MIN",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "MIN",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "errorTuples",
+                                    "filter": "number",
+                                    "id": "errorTuples:MAX",
+                                    "key": "errorTuples:MAX",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "MAX",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "errorTuples",
+                                    "filter": "number",
+                                    "id": "errorTuples:COUNT",
+                                    "key": "errorTuples:COUNT",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "COUNT",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "errorTuples",
+                                    "filter": "number",
+                                    "id": "errorTuples:FIRST",
+                                    "key": "errorTuples:FIRST",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "FIRST",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "errorTuples",
+                                    "filter": "number",
+                                    "id": "errorTuples:LAST",
+                                    "key": "errorTuples:LAST",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "LAST",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "errorTuples",
+                                    "filter": "number",
+                                    "id": "errorTuples:AVG",
+                                    "key": "errorTuples:AVG",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "AVG",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "totalBadEvents",
+                                    "filter": "number",
+                                    "id": "totalBadEvents:SUM",
+                                    "key": "totalBadEvents:SUM",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "SUM",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "totalBadEvents",
+                                    "filter": "number",
+                                    "id": "totalBadEvents:MIN",
+                                    "key": "totalBadEvents:MIN",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "MIN",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "totalBadEvents",
+                                    "filter": "number",
+                                    "id": "totalBadEvents:MAX",
+                                    "key": "totalBadEvents:MAX",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "MAX",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "totalBadEvents",
+                                    "filter": "number",
+                                    "id": "totalBadEvents:COUNT",
+                                    "key": "totalBadEvents:COUNT",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "COUNT",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "totalBadEvents",
+                                    "filter": "number",
+                                    "id": "totalBadEvents:FIRST",
+                                    "key": "totalBadEvents:FIRST",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "FIRST",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "totalBadEvents",
+                                    "filter": "number",
+                                    "id": "totalBadEvents:LAST",
+                                    "key": "totalBadEvents:LAST",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "LAST",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "totalBadEvents",
+                                    "filter": "number",
+                                    "id": "totalBadEvents:AVG",
+                                    "key": "totalBadEvents:AVG",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "AVG",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "tuplesWrittenSuccessfully",
+                                    "filter": "number",
+                                    "id": "tuplesWrittenSuccessfully:SUM",
+                                    "key": "tuplesWrittenSuccessfully:SUM",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "SUM",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "tuplesWrittenSuccessfully",
+                                    "filter": "number",
+                                    "id": "tuplesWrittenSuccessfully:MIN",
+                                    "key": "tuplesWrittenSuccessfully:MIN",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "MIN",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "tuplesWrittenSuccessfully",
+                                    "filter": "number",
+                                    "id": "tuplesWrittenSuccessfully:MAX",
+                                    "key": "tuplesWrittenSuccessfully:MAX",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "MAX",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "tuplesWrittenSuccessfully",
+                                    "filter": "number",
+                                    "id": "tuplesWrittenSuccessfully:COUNT",
+                                    "key": "tuplesWrittenSuccessfully:COUNT",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "COUNT",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "tuplesWrittenSuccessfully",
+                                    "filter": "number",
+                                    "id": "tuplesWrittenSuccessfully:FIRST",
+                                    "key": "tuplesWrittenSuccessfully:FIRST",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "FIRST",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "tuplesWrittenSuccessfully",
+                                    "filter": "number",
+                                    "id": "tuplesWrittenSuccessfully:LAST",
+                                    "key": "tuplesWrittenSuccessfully:LAST",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "LAST",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "tuplesWrittenSuccessfully",
+                                    "filter": "number",
+                                    "id": "tuplesWrittenSuccessfully:AVG",
+                                    "key": "tuplesWrittenSuccessfully:AVG",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "AVG",
+                                    "type": "long"
+                                }
+                            ],
+                            "keyFields": [
+                                {
+                                    "filter": "like",
+                                    "id": "appName",
+                                    "key": "appName",
+                                    "sort": "string",
+                                    "type": "string"
+                                },
+                                {
+                                    "filter": "like",
+                                    "id": "appUser",
+                                    "key": "appUser",
+                                    "sort": "string",
+                                    "type": "string"
+                                },
+                                {
+                                    "filter": "like",
+                                    "id": "logicalOperatorName",
+                                    "key": "logicalOperatorName",
+                                    "sort": "string",
+                                    "type": "string"
+                                }
+                            ],
+                            "keys": [
+                                {
+                                    "enumValues": [
+                                        "Database-to-Database-Sync"
+                                    ],
+                                    "name": "appName",
+                                    "type": "string"
+                                },
+                                {
+                                    "enumValues": [
+                                        "deepak"
+                                    ],
+                                    "name": "appUser",
+                                    "type": "string"
+                                },
+                                {
+                                    "enumValues": [
+                                        "JdbcOutput"
+                                    ],
+                                    "name": "logicalOperatorName",
+                                    "type": "string"
+                                }
+                            ],
+                            "schemaType": "dimensions",
+                            "schemaVersion": "1.0",
+                            "time": {
+                                "buckets": [
+                                    "1m",
+                                    "1h",
+                                    "1d"
+                                ],
+                                "slidingAggregateSupported": true
+                            },
+                            "timeFields": [
+                                {
+                                    "filter": "date",
+                                    "id": "time",
+                                    "key": "time",
+                                    "ngFilter": "date:'yyyy-MM-dd HH:mm:ss Z'",
+                                    "sort": "number",
+                                    "type": "date"
+                                }
+                            ],
+                            "valueFields": [],
+                            "valueFieldsAllDimensions": [
+                                {
+                                    "category": "eventsWrittenPerSecond",
+                                    "filter": "number",
+                                    "id": "eventsWrittenPerSecond:SUM",
+                                    "key": "eventsWrittenPerSecond:SUM",
+                                    "selected": true,
+                                    "sort": "number",
+                                    "subcategory": "SUM",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "eventsWrittenPerSecond",
+                                    "filter": "number",
+                                    "id": "eventsWrittenPerSecond:MIN",
+                                    "key": "eventsWrittenPerSecond:MIN",
+                                    "selected": true,
+                                    "sort": "number",
+                                    "subcategory": "MIN",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "eventsWrittenPerSecond",
+                                    "filter": "number",
+                                    "id": "eventsWrittenPerSecond:MAX",
+                                    "key": "eventsWrittenPerSecond:MAX",
+                                    "selected": true,
+                                    "sort": "number",
+                                    "subcategory": "MAX",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "eventsWrittenPerSecond",
+                                    "filter": "number",
+                                    "id": "eventsWrittenPerSecond:COUNT",
+                                    "key": "eventsWrittenPerSecond:COUNT",
+                                    "selected": true,
+                                    "sort": "number",
+                                    "subcategory": "COUNT",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "eventsWrittenPerSecond",
+                                    "filter": "number",
+                                    "id": "eventsWrittenPerSecond:FIRST",
+                                    "key": "eventsWrittenPerSecond:FIRST",
+                                    "selected": true,
+                                    "sort": "number",
+                                    "subcategory": "FIRST",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "eventsWrittenPerSecond",
+                                    "filter": "number",
+                                    "id": "eventsWrittenPerSecond:LAST",
+                                    "key": "eventsWrittenPerSecond:LAST",
+                                    "selected": true,
+                                    "sort": "number",
+                                    "subcategory": "LAST",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "eventsWrittenPerSecond",
+                                    "filter": "number",
+                                    "id": "eventsWrittenPerSecond:AVG",
+                                    "key": "eventsWrittenPerSecond:AVG",
+                                    "selected": true,
+                                    "sort": "number",
+                                    "subcategory": "AVG",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "totalEventsWritten",
+                                    "filter": "number",
+                                    "id": "totalEventsWritten:SUM",
+                                    "key": "totalEventsWritten:SUM",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "SUM",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "totalEventsWritten",
+                                    "filter": "number",
+                                    "id": "totalEventsWritten:MIN",
+                                    "key": "totalEventsWritten:MIN",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "MIN",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "totalEventsWritten",
+                                    "filter": "number",
+                                    "id": "totalEventsWritten:MAX",
+                                    "key": "totalEventsWritten:MAX",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "MAX",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "totalEventsWritten",
+                                    "filter": "number",
+                                    "id": "totalEventsWritten:COUNT",
+                                    "key": "totalEventsWritten:COUNT",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "COUNT",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "totalEventsWritten",
+                                    "filter": "number",
+                                    "id": "totalEventsWritten:FIRST",
+                                    "key": "totalEventsWritten:FIRST",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "FIRST",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "totalEventsWritten",
+                                    "filter": "number",
+                                    "id": "totalEventsWritten:LAST",
+                                    "key": "totalEventsWritten:LAST",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "LAST",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "totalEventsWritten",
+                                    "filter": "number",
+                                    "id": "totalEventsWritten:AVG",
+                                    "key": "totalEventsWritten:AVG",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "AVG",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "errorTuples",
+                                    "filter": "number",
+                                    "id": "errorTuples:SUM",
+                                    "key": "errorTuples:SUM",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "SUM",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "errorTuples",
+                                    "filter": "number",
+                                    "id": "errorTuples:MIN",
+                                    "key": "errorTuples:MIN",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "MIN",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "errorTuples",
+                                    "filter": "number",
+                                    "id": "errorTuples:MAX",
+                                    "key": "errorTuples:MAX",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "MAX",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "errorTuples",
+                                    "filter": "number",
+                                    "id": "errorTuples:COUNT",
+                                    "key": "errorTuples:COUNT",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "COUNT",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "errorTuples",
+                                    "filter": "number",
+                                    "id": "errorTuples:FIRST",
+                                    "key": "errorTuples:FIRST",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "FIRST",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "errorTuples",
+                                    "filter": "number",
+                                    "id": "errorTuples:LAST",
+                                    "key": "errorTuples:LAST",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "LAST",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "errorTuples",
+                                    "filter": "number",
+                                    "id": "errorTuples:AVG",
+                                    "key": "errorTuples:AVG",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "AVG",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "totalBadEvents",
+                                    "filter": "number",
+                                    "id": "totalBadEvents:SUM",
+                                    "key": "totalBadEvents:SUM",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "SUM",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "totalBadEvents",
+                                    "filter": "number",
+                                    "id": "totalBadEvents:MIN",
+                                    "key": "totalBadEvents:MIN",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "MIN",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "totalBadEvents",
+                                    "filter": "number",
+                                    "id": "totalBadEvents:MAX",
+                                    "key": "totalBadEvents:MAX",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "MAX",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "totalBadEvents",
+                                    "filter": "number",
+                                    "id": "totalBadEvents:COUNT",
+                                    "key": "totalBadEvents:COUNT",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "COUNT",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "totalBadEvents",
+                                    "filter": "number",
+                                    "id": "totalBadEvents:FIRST",
+                                    "key": "totalBadEvents:FIRST",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "FIRST",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "totalBadEvents",
+                                    "filter": "number",
+                                    "id": "totalBadEvents:LAST",
+                                    "key": "totalBadEvents:LAST",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "LAST",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "totalBadEvents",
+                                    "filter": "number",
+                                    "id": "totalBadEvents:AVG",
+                                    "key": "totalBadEvents:AVG",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "AVG",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "tuplesWrittenSuccessfully",
+                                    "filter": "number",
+                                    "id": "tuplesWrittenSuccessfully:SUM",
+                                    "key": "tuplesWrittenSuccessfully:SUM",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "SUM",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "tuplesWrittenSuccessfully",
+                                    "filter": "number",
+                                    "id": "tuplesWrittenSuccessfully:MIN",
+                                    "key": "tuplesWrittenSuccessfully:MIN",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "MIN",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "tuplesWrittenSuccessfully",
+                                    "filter": "number",
+                                    "id": "tuplesWrittenSuccessfully:MAX",
+                                    "key": "tuplesWrittenSuccessfully:MAX",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "MAX",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "tuplesWrittenSuccessfully",
+                                    "filter": "number",
+                                    "id": "tuplesWrittenSuccessfully:COUNT",
+                                    "key": "tuplesWrittenSuccessfully:COUNT",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "COUNT",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "tuplesWrittenSuccessfully",
+                                    "filter": "number",
+                                    "id": "tuplesWrittenSuccessfully:FIRST",
+                                    "key": "tuplesWrittenSuccessfully:FIRST",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "FIRST",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "tuplesWrittenSuccessfully",
+                                    "filter": "number",
+                                    "id": "tuplesWrittenSuccessfully:LAST",
+                                    "key": "tuplesWrittenSuccessfully:LAST",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "LAST",
+                                    "type": "long"
+                                },
+                                {
+                                    "category": "tuplesWrittenSuccessfully",
+                                    "filter": "number",
+                                    "id": "tuplesWrittenSuccessfully:AVG",
+                                    "key": "tuplesWrittenSuccessfully:AVG",
+                                    "selected": false,
+                                    "sort": "number",
+                                    "subcategory": "AVG",
+                                    "type": "long"
+                                }
+                            ],
+                            "values": []
+                        },
+                        "tags": {
+                            "multiKeySelect": true
+                        }
+                    },
+                    "name": "line chart",
+                    "size": {
+                        "contentOverflow": "hidden",
+                        "minHeight": "300px",
+                        "minWidth": "500px",
+                        "width": "50%"
+                    },
+                    "style": {},
+                    "title": "Line Chart"
+                },
+                {
+                    "dataModelOptions": {
+                        "chart": {
+                            "keyField": "eventsReadPerSecond",
+                            "valueField": "totalEventsRead",
+                            "valueFields": [
+                                "eventsReadPerSecond",
+                                "totalEventsRead"
+                            ]
+                        },
+                        "dataQueryParams": {
+                            "data": {
+                                "fields": [
+                                    "eventsReadPerSecond",
+                                    "totalEventsRead"
+                                ],
+                                "schemaKeys": {
+                                    "appName": "Database-to-Database-Sync",
+                                    "appUser": "deepak",
+                                    "logicalOperatorName": "JdbcInput"
+                                }
+                            },
+                            "getDataContinuously": true,
+                            "incompleteResultOK": true
+                        },
+                        "dataSource": {
+                            "appName": "Database-to-Database-Sync",
+                            "appPackageSource": {
+                                "appName": "Database-to-Database-Sync",
+                                "name": "database-to-database-sync",
+                                "user": "deepak",
+                                "version": "0.9.0"
+                            },
+                            "appUser": "deepak",
+                            "context": {
+                                "schemaKeys": {
+                                    "appName": "Database-to-Database-Sync",
+                                    "appUser": "deepak",
+                                    "logicalOperatorName": "JdbcInput"
+                                }
+                            },
+                            "displayName": "Snapshot :: Operator Metrics : JdbcInput (user: deepak; app: Database-to-Database-Sync)",
+                            "name": "Snapshot :: Operator Metrics : JdbcInput",
+                            "query": {
+                                "operatorName": "MetricsStore.query",
+                                "topic": "DTMetricsQuery",
+                                "url": "pubsub"
+                            },
+                            "result": {
+                                "appendQIDToTopic": true,
+                                "operatorName": "MetricsResult",
+                                "topic": "DTMetricsResult",
+                                "url": "pubsub"
+                            },
+                            "type": "metrics"
+                        },
+                        "loadingData": false,
+                        "schema": {
+                            "fieldSelectionColumns": [
+                                {
+                                    "id": "selector",
+                                    "key": "id",
+                                    "label": "",
+                                    "lockWidth": true,
+                                    "selector": true,
+                                    "width": "40px"
+                                },
+                                {
+                                    "filter": "like",
+                                    "id": "id",
+                                    "key": "id",
+                                    "sort": "string"
+                                },
+                                {
+                                    "filter": "like",
+                                    "id": "type",
+                                    "key": "type",
+                                    "sort": "string"
+                                }
+                            ],
+                            "fieldSelectionOptions": {
+                                "bgSizeMultiplier": "2",
+                                "defaultRowHeight": "29",
+                                "initialSorts": [
+                                    {
+                                        "dir": "+",
+                                        "id": "id"
+                                    }
+                                ],
+                                "loading": false
+                            },
+                            "fields": [
+                                {
+                                    "filter": "like",
+                                    "id": "eventsReadPerSecond",
+                                    "key": "eventsReadPerSecond",
+                                    "sort": "string",
+                                    "type": "long"
+                                },
+                                {
+                                    "filter": "like",
+                                    "id": "totalEventsRead",
+                                    "key": "totalEventsRead",
+                                    "sort": "string",
+                                    "type": "long"
+                                }
+                            ],
+                            "schemaKeys": {
+                                "appName": "Database-to-Database-Sync",
+                                "appUser": "deepak",
+                                "logicalOperatorName": "JdbcInput"
+                            },
+                            "schemaType": "snapshot",
+                            "schemaVersion": "1.0",
+                            "values": [
+                                {
+                                    "name": "eventsReadPerSecond",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "totalEventsRead",
+                                    "type": "long"
+                                }
+                            ]
+                        },
+                        "sortOptions": {
+                            "direction": "asc",
+                            "enabled": false,
+                            "key": {
+                                "name": "eventsReadPerSecond",
+                                "type": "long"
+                            }
+                        }
+                    },
+                    "name": "snapshot single value",
+                    "size": {
+                        "width": "15%"
+                    },
+                    "style": {},
+                    "title": "Single Value"
+                },
+                {
+                    "dataModelOptions": {
+                        "chart": {
+                            "keyField": "eventsWrittenPerSecond",
+                            "valueField": "totalEventsWritten",
+                            "valueFields": [
+                                "eventsWrittenPerSecond",
+                                "totalEventsWritten",
+                                "errorTuples",
+                                "totalBadEvents",
+                                "tuplesWrittenSuccessfully"
+                            ]
+                        },
+                        "dataQueryParams": {
+                            "data": {
+                                "fields": [
+                                    "eventsWrittenPerSecond",
+                                    "totalEventsWritten",
+                                    "errorTuples",
+                                    "totalBadEvents",
+                                    "tuplesWrittenSuccessfully"
+                                ],
+                                "schemaKeys": {
+                                    "appName": "Database-to-Database-Sync",
+                                    "appUser": "deepak",
+                                    "logicalOperatorName": "JdbcOutput"
+                                }
+                            },
+                            "getDataContinuously": true,
+                            "incompleteResultOK": true
+                        },
+                        "dataSource": {
+                            "appName": "Database-to-Database-Sync",
+                            "appPackageSource": {
+                                "appName": "Database-to-Database-Sync",
+                                "name": "database-to-database-sync",
+                                "user": "deepak",
+                                "version": "0.9.0"
+                            },
+                            "appUser": "deepak",
+                            "context": {
+                                "schemaKeys": {
+                                    "appName": "Database-to-Database-Sync",
+                                    "appUser": "deepak",
+                                    "logicalOperatorName": "JdbcOutput"
+                                }
+                            },
+                            "displayName": "Snapshot :: Operator Metrics : JdbcOutput (user: deepak; app: Database-to-Database-Sync)",
+                            "name": "Snapshot :: Operator Metrics : JdbcOutput",
+                            "query": {
+                                "operatorName": "MetricsStore.query",
+                                "topic": "DTMetricsQuery",
+                                "url": "pubsub"
+                            },
+                            "result": {
+                                "appendQIDToTopic": true,
+                                "operatorName": "MetricsResult",
+                                "topic": "DTMetricsResult",
+                                "url": "pubsub"
+                            },
+                            "type": "metrics"
+                        },
+                        "loadingData": false,
+                        "schema": {
+                            "fieldSelectionColumns": [
+                                {
+                                    "id": "selector",
+                                    "key": "id",
+                                    "label": "",
+                                    "lockWidth": true,
+                                    "selector": true,
+                                    "width": "40px"
+                                },
+                                {
+                                    "filter": "like",
+                                    "id": "id",
+                                    "key": "id",
+                                    "sort": "string"
+                                },
+                                {
+                                    "filter": "like",
+                                    "id": "type",
+                                    "key": "type",
+                                    "sort": "string"
+                                }
+                            ],
+                            "fieldSelectionOptions": {
+                                "bgSizeMultiplier": "2",
+                                "defaultRowHeight": "29",
+                                "initialSorts": [
+                                    {
+                                        "dir": "+",
+                                        "id": "id"
+                                    }
+                                ],
+                                "loading": false
+                            },
+                            "fields": [
+                                {
+                                    "filter": "like",
+                                    "id": "eventsWrittenPerSecond",
+                                    "key": "eventsWrittenPerSecond",
+                                    "sort": "string",
+                                    "type": "long"
+                                },
+                                {
+                                    "filter": "like",
+                                    "id": "totalEventsWritten",
+                                    "key": "totalEventsWritten",
+                                    "sort": "string",
+                                    "type": "long"
+                                },
+                                {
+                                    "filter": "like",
+                                    "id": "errorTuples",
+                                    "key": "errorTuples",
+                                    "sort": "string",
+                                    "type": "long"
+                                },
+                                {
+                                    "filter": "like",
+                                    "id": "totalBadEvents",
+                                    "key": "totalBadEvents",
+                                    "sort": "string",
+                                    "type": "long"
+                                },
+                                {
+                                    "filter": "like",
+                                    "id": "tuplesWrittenSuccessfully",
+                                    "key": "tuplesWrittenSuccessfully",
+                                    "sort": "string",
+                                    "type": "long"
+                                }
+                            ],
+                            "schemaKeys": {
+                                "appName": "Database-to-Database-Sync",
+                                "appUser": "deepak",
+                                "logicalOperatorName": "JdbcOutput"
+                            },
+                            "schemaType": "snapshot",
+                            "schemaVersion": "1.0",
+                            "values": [
+                                {
+                                    "name": "eventsWrittenPerSecond",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "totalEventsWritten",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "errorTuples",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "totalBadEvents",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "tuplesWrittenSuccessfully",
+                                    "type": "long"
+                                }
+                            ]
+                        },
+                        "sortOptions": {
+                            "direction": "asc",
+                            "enabled": false,
+                            "key": {
+                                "name": "eventsWrittenPerSecond",
+                                "type": "long"
+                            }
+                        }
+                    },
+                    "name": "snapshot single value",
+                    "size": {
+                        "width": "16.69359181475498%"
+                    },
+                    "style": {},
+                    "title": "Single Value"
+                },
+                {
+                    "dataModelOptions": {
+                        "chart": {
+                            "keyField": "eventsWrittenPerSecond",
+                            "valueField": "totalBadEvents",
+                            "valueFields": [
+                                "eventsWrittenPerSecond",
+                                "totalEventsWritten",
+                                "errorTuples",
+                                "totalBadEvents",
+                                "tuplesWrittenSuccessfully"
+                            ]
+                        },
+                        "dataQueryParams": {
+                            "data": {
+                                "fields": [
+                                    "eventsWrittenPerSecond",
+                                    "totalEventsWritten",
+                                    "errorTuples",
+                                    "totalBadEvents",
+                                    "tuplesWrittenSuccessfully"
+                                ],
+                                "schemaKeys": {
+                                    "appName": "Database-to-Database-Sync",
+                                    "appUser": "deepak",
+                                    "logicalOperatorName": "JdbcOutput"
+                                }
+                            },
+                            "getDataContinuously": true,
+                            "incompleteResultOK": true
+                        },
+                        "dataSource": {
+                            "appName": "Database-to-Database-Sync",
+                            "appPackageSource": {
+                                "appName": "Database-to-Database-Sync",
+                                "name": "database-to-database-sync",
+                                "user": "deepak",
+                                "version": "0.9.0"
+                            },
+                            "appUser": "deepak",
+                            "context": {
+                                "schemaKeys": {
+                                    "appName": "Database-to-Database-Sync",
+                                    "appUser": "deepak",
+                                    "logicalOperatorName": "JdbcOutput"
+                                }
+                            },
+                            "displayName": "Snapshot :: Operator Metrics : JdbcOutput (user: deepak; app: Database-to-Database-Sync)",
+                            "name": "Snapshot :: Operator Metrics : JdbcOutput",
+                            "query": {
+                                "operatorName": "MetricsStore.query",
+                                "topic": "DTMetricsQuery",
+                                "url": "pubsub"
+                            },
+                            "result": {
+                                "appendQIDToTopic": true,
+                                "operatorName": "MetricsResult",
+                                "topic": "DTMetricsResult",
+                                "url": "pubsub"
+                            },
+                            "type": "metrics"
+                        },
+                        "loadingData": false,
+                        "schema": {
+                            "fieldSelectionColumns": [
+                                {
+                                    "id": "selector",
+                                    "key": "id",
+                                    "label": "",
+                                    "lockWidth": true,
+                                    "selector": true,
+                                    "width": "40px"
+                                },
+                                {
+                                    "filter": "like",
+                                    "id": "id",
+                                    "key": "id",
+                                    "sort": "string"
+                                },
+                                {
+                                    "filter": "like",
+                                    "id": "type",
+                                    "key": "type",
+                                    "sort": "string"
+                                }
+                            ],
+                            "fieldSelectionOptions": {
+                                "bgSizeMultiplier": "2",
+                                "defaultRowHeight": "29",
+                                "initialSorts": [
+                                    {
+                                        "dir": "+",
+                                        "id": "id"
+                                    }
+                                ],
+                                "loading": false
+                            },
+                            "fields": [
+                                {
+                                    "filter": "like",
+                                    "id": "eventsWrittenPerSecond",
+                                    "key": "eventsWrittenPerSecond",
+                                    "sort": "string",
+                                    "type": "long"
+                                },
+                                {
+                                    "filter": "like",
+                                    "id": "totalEventsWritten",
+                                    "key": "totalEventsWritten",
+                                    "sort": "string",
+                                    "type": "long"
+                                },
+                                {
+                                    "filter": "like",
+                                    "id": "errorTuples",
+                                    "key": "errorTuples",
+                                    "sort": "string",
+                                    "type": "long"
+                                },
+                                {
+                                    "filter": "like",
+                                    "id": "totalBadEvents",
+                                    "key": "totalBadEvents",
+                                    "sort": "string",
+                                    "type": "long"
+                                },
+                                {
+                                    "filter": "like",
+                                    "id": "tuplesWrittenSuccessfully",
+                                    "key": "tuplesWrittenSuccessfully",
+                                    "sort": "string",
+                                    "type": "long"
+                                }
+                            ],
+                            "schemaKeys": {
+                                "appName": "Database-to-Database-Sync",
+                                "appUser": "deepak",
+                                "logicalOperatorName": "JdbcOutput"
+                            },
+                            "schemaType": "snapshot",
+                            "schemaVersion": "1.0",
+                            "values": [
+                                {
+                                    "name": "eventsWrittenPerSecond",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "totalEventsWritten",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "errorTuples",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "totalBadEvents",
+                                    "type": "long"
+                                },
+                                {
+                                    "name": "tuplesWrittenSuccessfully",
+                                    "type": "long"
+                                }
+                            ]
+                        },
+                        "sortOptions": {
+                            "direction": "asc",
+                            "enabled": false,
+                            "key": {
+                                "name": "eventsWrittenPerSecond",
+                                "type": "long"
+                            }
+                        }
+                    },
+                    "name": "snapshot single value",
+                    "size": {
+                        "width": "15%"
+                    },
+                    "style": {},
+                    "title": "Single Value"
+                }
+            ]
+        }
+    },
+    "description": "automatically generated dashboard",
+    "id": "deepak:Database-to-Database-Sync",
+    "mtime": "2017-06-26T08:59:00.401Z",
+    "name": "Database-to-Database-Sync",
+    "user": "deepak"
+}

--- a/app-templates/database-to-database-sync/src/main/resources/resources/ui/ui.json
+++ b/app-templates/database-to-database-sync/src/main/resources/resources/ui/ui.json
@@ -1,0 +1,9 @@
+{
+  "dashboards": [
+    {
+      "name": "Database to Database Sync App",
+      "file": "Database-to-Database-Sync.dtdashboard",
+      "appNames": ["Database-to-Database-Sync"]
+    }
+  ]
+}

--- a/app-templates/pom.xml
+++ b/app-templates/pom.xml
@@ -173,10 +173,16 @@
       <artifactId>metrics-lib-writer</artifactId>
       <version>3.9.0-SNAPSHOT</version>
     </dependency>
+    <dependency>
+      <groupId>com.datatorrent</groupId>
+      <artifactId>metrics-plugin</artifactId>
+      <version>3.9.0-SNAPSHOT</version>
+    </dependency>
   </dependencies>
 	
   <modules>
     <!-- Add individual app templates as modules here -->
+    <module>database-to-database-sync</module>
     <module>hdfs-to-hdfs-filter-transform</module>
     <module>hdfs-line-copy</module>
     <module>kafka-to-hdfs-filter-transform</module>

--- a/operators/library/src/main/java/com/datatorrent/moodi/lib/io/db/JdbcPOJOInsertOutputOperator.java
+++ b/operators/library/src/main/java/com/datatorrent/moodi/lib/io/db/JdbcPOJOInsertOutputOperator.java
@@ -1,0 +1,64 @@
+package com.datatorrent.moodi.lib.io.db;
+
+import com.datatorrent.api.AutoMetric;
+import com.datatorrent.api.Context;
+
+/**
+ * JdbcPOJOInsertOutputOperator extends from com.datatorrent.lib.db.jdbc.JdbcPOJOInsertOutputOperator.
+ * It emits the bytesWrittenPerSecond, bytesWritten, totalEventsWritten, eventsWrittenPerSecond metrics.
+ *
+ */
+public class JdbcPOJOInsertOutputOperator extends com.datatorrent.lib.db.jdbc.JdbcPOJOInsertOutputOperator
+{
+  @AutoMetric
+  private long totalEventsWritten = 0;
+
+  @AutoMetric
+  private long totalBadEvents = 0;
+
+  @AutoMetric
+  private transient long eventsWrittenPerSecond;
+
+  private transient long eventsWrittenPerWindow;
+  private transient double windowTimeSec;
+
+  @Override
+  public void setup(Context.OperatorContext context)
+  {
+    super.setup(context);
+    windowTimeSec = (context.getValue(Context.OperatorContext.APPLICATION_WINDOW_COUNT) *
+      context.getValue(Context.DAGContext.STREAMING_WINDOW_SIZE_MILLIS) * 1.0) / 1000.0;
+  }
+
+  @Override
+  public void beginWindow(long windowId)
+  {
+    super.beginWindow(windowId);
+    eventsWrittenPerWindow = 0;
+    eventsWrittenPerSecond = 0;
+  }
+
+  @Override
+  public void processTuple(Object tuple)
+  {
+    eventsWrittenPerWindow += 1;
+    super.processTuple(tuple);
+    /*
+     * due to issue in malhar operator AbstractTransactionalOutputOperator, below calculation is required
+     * Once the issue is fixed in operator below code would be changed.
+     */
+    if (getTuplesWrittenSuccessfully() > 0) {
+      totalBadEvents += eventsWrittenPerWindow - getTuplesWrittenSuccessfully();
+      eventsWrittenPerWindow = getTuplesWrittenSuccessfully();
+    }
+  }
+
+  @Override
+  public void endWindow()
+  {
+    super.endWindow();
+    eventsWrittenPerSecond = (long)(eventsWrittenPerWindow/windowTimeSec);
+    totalEventsWritten += eventsWrittenPerWindow;
+  }
+}
+

--- a/operators/library/src/main/java/com/datatorrent/moodi/lib/io/db/JdbcPOJOPollInputOperator.java
+++ b/operators/library/src/main/java/com/datatorrent/moodi/lib/io/db/JdbcPOJOPollInputOperator.java
@@ -1,0 +1,53 @@
+package com.datatorrent.moodi.lib.io.db;
+
+import com.datatorrent.api.AutoMetric;
+import com.datatorrent.api.Context;
+
+/**
+ * JdbcPOJOPollInputOperator extends from com.datatorrent.lib.db.jdbc.JdbcPOJOPollInputOperator.
+ * It emits the bytesReadPerSecond, bytesRead, totalEventsRead, eventsReadPerSecond metrics.
+ *
+ */
+public class JdbcPOJOPollInputOperator extends com.datatorrent.lib.db.jdbc.JdbcPOJOPollInputOperator
+{
+  @AutoMetric
+  private long totalEventsRead = 0;
+
+  @AutoMetric
+  private transient long eventsReadPerSecond;
+
+  private transient long eventsReadPerWindow;
+  private transient double windowTimeSec;
+
+  @Override
+  public void setup(Context.OperatorContext context)
+  {
+    super.setup(context);
+    windowTimeSec = (context.getValue(Context.OperatorContext.APPLICATION_WINDOW_COUNT) *
+      context.getValue(Context.DAGContext.STREAMING_WINDOW_SIZE_MILLIS) * 1.0) / 1000.0;
+  }
+
+  @Override
+  public void beginWindow(long windowId)
+  {
+    super.beginWindow(windowId);
+    eventsReadPerWindow = 0;
+    eventsReadPerSecond = 0;
+  }
+
+  @Override
+  protected void emitTuple(Object obj)
+  {
+    super.emitTuple(obj);
+    eventsReadPerWindow++;
+  }
+
+  @Override
+  public void endWindow()
+  {
+    super.endWindow();
+    eventsReadPerSecond = (long)(eventsReadPerWindow/windowTimeSec);
+    totalEventsRead += eventsReadPerWindow;
+  }
+}
+

--- a/operators/pom.xml
+++ b/operators/pom.xml
@@ -19,6 +19,5 @@
     <module>library</module>
     <module>contrib</module>
   </modules>
-  
-  
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,19 @@
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>2.3.2</version>
+        <configuration>
+          <encoding>UTF-8</encoding>
+          <source>1.7</source>
+          <target>1.7</target>
+          <debug>true</debug>
+          <optimize>false</optimize>
+          <showDeprecation>true</showDeprecation>
+          <showWarnings>true</showWarnings>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <version>2.17</version>


### PR DESCRIPTION
1) Extension of Jdbc poller and output operators with added metrics.
2) Changes to Database to database sync app to reflect extended operators.

Conflicts:
	app-templates/pom.xml