### PR TITLE
SPOI-12344 Adding update and docIdField properties to elasticsearch app-template . [ Merge after SPOI-12340]

### DIFF
--- a/app-templates/kafka-to-elastic-search-transform/pom.xml
+++ b/app-templates/kafka-to-elastic-search-transform/pom.xml
@@ -393,7 +393,7 @@
     <dependency>
       <groupId>com.datatorrent</groupId>
       <artifactId>dt-elasticsearch</artifactId>
-      <version>0.1.0-SNAPSHOT</version>
+      <version>1.3.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>info.batey.kafka</groupId>

--- a/app-templates/kafka-to-elastic-search-transform/src/main/resources/META-INF/properties.xml
+++ b/app-templates/kafka-to-elastic-search-transform/src/main/resources/META-INF/properties.xml
@@ -65,6 +65,25 @@
 
   <!-- Optional properties for Elastic Search operator. -->
   <property>
+    <name>apex.app-param.EnableDocumentUpdate</name>
+    <description>Enable updating existing document if new document with same id is stored. Default : false</description>
+  </property>
+  <property>
+    <name>dt.operator.ElasticStore.prop.update</name>
+    <value>${apex.app-param.EnableDocumentUpdate}</value>
+  </property>
+
+  <property>
+    <name>apex.app-param.FieldToConsiderAsDocId</name>
+    <description>The field in the json document that should be considered as the _id. Mandatory Field when update ==
+      true. Default : hashcode of tuple</description>
+  </property>
+  <property>
+    <name>dt.operator.ElasticStore.prop.docIdField</name>
+    <value>${apex.app-param.FieldToConsiderAsDocId}</value>
+  </property>
+
+  <property>
     <name>apex.app-param.indexName</name>
     <description>Specify the index name for elastic store.</description>
   </property>


### PR DESCRIPTION
Adding new properties to properties.xml file of kafka-to-elastic-search-transform app template as newly introduced by SPOI-12340.

Also updating the dt-elasticsearch dependency version to latest. 1.3.0-SNAPSHOT.